### PR TITLE
Updated README to mention env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Interactive editor for fabrix framework
 
 ## Setup
 
+Before setup, you have to set `VITE_GRAPHQL_ENDPOINT_URL` in your environment.
+
+You can use an example GQL server by copy-pasting the configuration below to `.env` in your local.
+
+```
+VITE_GRAPHQL_ENDPOINT_URL=https://starwars-9teh3dbd8w.erp.dev/query`
+```
+
+Then, spin up an editor app.
+
 ```
 pnpm install
 ```


### PR DESCRIPTION
Editor needs `VITE_GRAPHQL_ENDPOINT_URL` to run, but nothing mentions it currently. This PR adds it on README.