### PR TITLE
fix error message when query is empty

### DIFF
--- a/src/builder/Editor.tsx
+++ b/src/builder/Editor.tsx
@@ -115,10 +115,15 @@ const useEditor = () => {
   const [editorQuery, setEditorQuery] = useState("");
   const [parsedQuery, setParsedQuery] = useState<DocumentNode | null>(null);
 
+  const trimComment = (query: string) => {
+    return query.replace(/#.*\n/g, "").trim();
+  }
+
   const updatePreview = useMemo(
     () =>
       R.debounce(
         (query: string) => {
+          query = trimComment(query);
           setEditorQuery(query);
 
           try {


### PR DESCRIPTION
When a query is empty(or only comments), the preview shows an error.

<img width="1315" alt="Screenshot 2024-09-28 at 12 09 05" src="https://github.com/user-attachments/assets/84e297a9-917e-4f3a-bc03-84f1e5545abd">

This pull request includes an enhancement to the `useEditor` hook in the `src/builder/Editor.tsx` file. The primary change is the addition of a new function to handle comment trimming within the editor query.

<img width="1321" alt="Screenshot 2024-09-28 at 12 08 52" src="https://github.com/user-attachments/assets/9bab681c-94d7-4b66-87d9-05c9c95da662">


Enhancements to `useEditor` hook:

* [`src/builder/Editor.tsx`](diffhunk://#diff-c1fadb42b88f9d8622016e6f12f944ef4c2dcf58aa492c85e95709ae411352bdR118-R126): Added a `trimComment` function to remove comments from the editor query before processing it. This function uses a regular expression to match and remove lines starting with `#`.