### PR TITLE
set request headers from graphiql editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@graphql-tools/schema": "^10.0.6",
     "@monaco-editor/react": "^4.6.0",
     "@tanstack/react-table": "^8.19.3",
+    "@urql/exchange-auth": "^2.2.0",
     "framer-motion": "^11.3.17",
     "graphiql": "^3.7.0",
     "graphql": "^16.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.19.3
         version: 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@urql/exchange-auth':
+        specifier: ^2.2.0
+        version: 2.2.0(@urql/core@5.0.6(graphql@16.9.0))
       framer-motion:
         specifier: ^11.3.17
         version: 11.5.0(@emotion/is-prop-valid@1.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1812,6 +1815,11 @@ packages:
 
   '@urql/core@5.0.6':
     resolution: {integrity: sha512-38rgSDqVNihFDauw1Pm9V7XLWIKuK8V9CKgrUF7/xEKinze8ENKP1ZeBhkG+dxWzJan7CHK+SLl46kAdvZwIlA==}
+
+  '@urql/exchange-auth@2.2.0':
+    resolution: {integrity: sha512-4bJR22EYa/flbhwMBj4lU8MI4cO3ddo/DX7FygWeaeHZU+RWfnQKifCKwxIYlnoV8/CgYRM4lFSMIByYlhmWcg==}
+    peerDependencies:
+      '@urql/core': ^5.0.0
 
   '@vitejs/plugin-react@4.3.1':
     resolution: {integrity: sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg==}
@@ -6532,6 +6540,11 @@ snapshots:
       wonka: 6.3.4
     transitivePeerDependencies:
       - graphql
+
+  '@urql/exchange-auth@2.2.0(@urql/core@5.0.6(graphql@16.9.0))':
+    dependencies:
+      '@urql/core': 5.0.6(graphql@16.9.0)
+      wonka: 6.3.4
 
   '@vitejs/plugin-react@4.3.1(vite@5.4.3(@types/node@22.5.3)(terser@5.31.6))':
     dependencies:

--- a/src/builder/panes/Editor.tsx
+++ b/src/builder/panes/Editor.tsx
@@ -97,6 +97,15 @@ export const EditorPane = (props: EditorPaneProps) => {
     }
     props.updatePreview(query);
   };
+  const onEditHeaders = (headers: string) => {
+    try {
+      builderContext.setAdditionalHeader(
+        JSON.parse(headers) as Record<string, string>,
+      );
+    } catch {
+      /* noop */
+    }
+  };
 
   const hasOpenAIToken =
     builderContext.openAIToken && builderContext.openAIToken.length > 0;
@@ -136,6 +145,7 @@ export const EditorPane = (props: EditorPaneProps) => {
                 fetcher={fetcher}
                 disableTabs={true}
                 onEditQuery={onEditQuery}
+                onEditHeaders={onEditHeaders}
                 plugins={[explorer, ...(hasOpenAIToken ? [openAIChat] : [])]}
                 defaultQuery={props.query}
                 schema={builderContext.schema}


### PR DESCRIPTION
Request headers are currently unavailable.
With this change, the headers entered in GraphiQL will be added to the GraphQL request headers.